### PR TITLE
WIP: Search & stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ now clone and run patchboard.
 git clone https://github.com/dominictarr/patchbay.git
 cd patchbay
 npm install electro electron-prebuilt -g
-patchwork plugins.install ssb-links # must have patchwork >=2.8
+patchwork plugins.install ssb-links ssb-query # must have patchwork >=2.8
 electro index.js
 ```
 

--- a/modules/channel.js
+++ b/modules/channel.js
@@ -1,0 +1,55 @@
+var h = require('hyperscript')
+var u = require('../util')
+var pull = require('pull-stream')
+var Scroller = require('pull-scroll')
+
+var plugs = require('../plugs')
+var message_render = plugs.first(exports.message_render = [])
+var message_compose = plugs.first(exports.message_compose = [])
+var sbot_log = plugs.first(exports.sbot_log = [])
+
+exports.message_meta = function (msg) {
+  var chan = msg.value.content.channel
+  if (chan)
+    return h('a', {href: '##'+chan}, '#'+chan)
+}
+
+exports.screen_view = function (path) {
+  if(path[0] === '#') {
+    var channel = path.substr(1)
+
+    var content = h('div.column.scroller__content')
+    var div = h('div.column.scroller',
+      {style: {'overflow':'auto'}},
+      h('div.scroller__wrapper',
+        message_compose({type: 'post'}), //header
+        content
+      )
+    )
+
+    function matchesChannel(msg) {
+      if (msg.sync) console.error('SYNC', msg)
+      var c = msg && msg.value && msg.value.content
+      return c && c.channel === channel
+    }
+
+    pull(
+      sbot_log({old: false}),
+      pull.filter(matchesChannel),
+      Scroller(div, content, message_render, true, false)
+    )
+
+    pull(
+      /*
+      sbot_query({query: [
+        {$filter: {value: {content: {channel: channel}}}}
+      ]}),
+      */
+      u.next(sbot_log, {reverse: true, limit: 100, live: false}),
+      pull.filter(matchesChannel),
+      Scroller(div, content, message_render, false, false)
+    )
+
+    return div
+  }
+}

--- a/modules/channel.js
+++ b/modules/channel.js
@@ -7,6 +7,7 @@ var plugs = require('../plugs')
 var message_render = plugs.first(exports.message_render = [])
 var message_compose = plugs.first(exports.message_compose = [])
 var sbot_log = plugs.first(exports.sbot_log = [])
+var sbot_query = plugs.first(exports.sbot_query = [])
 
 exports.message_meta = function (msg) {
   var chan = msg.value.content.channel
@@ -40,13 +41,9 @@ exports.screen_view = function (path) {
     )
 
     pull(
-      /*
       sbot_query({query: [
         {$filter: {value: {content: {channel: channel}}}}
       ]}),
-      */
-      u.next(sbot_log, {reverse: true, limit: 100, live: false}),
-      pull.filter(matchesChannel),
       Scroller(div, content, message_render, false, false)
     )
 

--- a/modules/channel.js
+++ b/modules/channel.js
@@ -41,7 +41,7 @@ exports.screen_view = function (path) {
     )
 
     pull(
-      sbot_query({query: [
+      sbot_query({reverse: true, query: [
         {$filter: {value: {content: {channel: channel}}}}
       ]}),
       Scroller(div, content, message_render, false, false)

--- a/modules/channel.js
+++ b/modules/channel.js
@@ -23,7 +23,7 @@ exports.screen_view = function (path) {
     var div = h('div.column.scroller',
       {style: {'overflow':'auto'}},
       h('div.scroller__wrapper',
-        message_compose({type: 'post'}), //header
+        message_compose({type: 'post', channel: channel}),
         content
       )
     )

--- a/modules/index.js
+++ b/modules/index.js
@@ -19,6 +19,7 @@ module.exports = [
   require('./post.js'),
   require('./private.js'),
   require('./public.js'),
+  require('./search.js'),
   require('./suggest-mentions.js'),
   require('./suggest.js'),
   require('./tabs.js'),

--- a/modules/index.js
+++ b/modules/index.js
@@ -21,6 +21,7 @@ module.exports = [
   require('./private.js'),
   require('./public.js'),
   require('./search.js'),
+  require('./search-box.js'),
   require('./suggest-mentions.js'),
   require('./suggest.js'),
   require('./tabs.js'),

--- a/modules/index.js
+++ b/modules/index.js
@@ -3,6 +3,7 @@ module.exports = [
   require('./avatar-image.js'),
   require('./avatar-profile.js'),
   require('./avatar.js'),
+  require('./channel.js'),
   require('./compose.js'),
   require('./crypto.js'),
   require('./feed.js'),

--- a/modules/search-box.js
+++ b/modules/search-box.js
@@ -1,0 +1,33 @@
+var h = require('hyperscript')
+
+exports.search_box = function (go) {
+
+  var search = h('input.searchprompt', {
+    type: 'search',
+    onkeydown: function (ev) {
+      switch (ev.keyCode) {
+        case 13: // enter
+          if (go(search.value, !ev.ctrlKey))
+            search.blur()
+          return
+        case 27: // escape
+          ev.preventDefault()
+          search.blur()
+          return
+      }
+    }
+  })
+
+  search.activate = function (sigil, ev) {
+    search.focus()
+    ev.preventDefault()
+    if (search.value[0] === sigil) {
+      search.selectionStart = 1
+      search.selectionEnd = search.value.length
+    } else {
+      search.value = sigil
+    }
+  }
+
+  return search
+}

--- a/modules/search-box.js
+++ b/modules/search-box.js
@@ -1,4 +1,8 @@
 var h = require('hyperscript')
+var suggest = require('suggest-box')
+var pull = require('pull-stream')
+var plugs = require('../plugs')
+var sbot_query = plugs.first(exports.sbot_query = [])
 
 exports.search_box = function (go) {
 
@@ -7,7 +11,7 @@ exports.search_box = function (go) {
     onkeydown: function (ev) {
       switch (ev.keyCode) {
         case 13: // enter
-          if (go(search.value, !ev.ctrlKey))
+          if (go(search.value.trim(), !ev.ctrlKey))
             search.blur()
           return
         case 27: // escape
@@ -28,6 +32,27 @@ exports.search_box = function (go) {
       search.value = sigil
     }
   }
+
+  /*
+  var suggestions = []
+
+  pull(
+    sbot_query({query: [
+      {$map: ['value', 'content', 'channel']},
+      {$filter: {$prefix: ''}}
+    ]}),
+    pull.unique(),
+    pull.drain(function (chan) {
+      console.log('chan', chan)
+      suggestions.push({title: '#'+chan, value: '#'+chan})
+    })
+  )
+
+  // delay until the element has a parent
+  setTimeout(function () {
+    suggest(search, {'#': suggestions})
+  }, 10)
+  */
 
   return search
 }

--- a/modules/search.js
+++ b/modules/search.js
@@ -1,0 +1,35 @@
+var h = require('hyperscript')
+var u = require('../util')
+var pull = require('pull-stream')
+var Scroller = require('pull-scroll')
+
+var plugs = require('../plugs')
+var message_render = plugs.first(exports.message_render = [])
+var sbot_search = plugs.first(exports.sbot_search = [])
+
+exports.screen_view = function (path) {
+  if(path[0] === '?') {
+    var query = path.substr(1)
+
+    var content = h('div.column.scroller__content')
+    var div = h('div.column.scroller',
+      {style: {'overflow':'auto'}},
+      h('div.scroller__wrapper',
+        content
+      )
+    )
+
+    pull(
+      sbot_search({query: query, old: false}),
+      Scroller(div, content, message_render, true, false)
+    )
+
+    pull(
+      u.next(sbot_search, {query: query,
+        reverse: true, limit: 100, live: false}),
+      Scroller(div, content, message_render, false, false)
+    )
+
+    return div
+  }
+}

--- a/modules/search.js
+++ b/modules/search.js
@@ -5,11 +5,24 @@ var Scroller = require('pull-scroll')
 
 var plugs = require('../plugs')
 var message_render = plugs.first(exports.message_render = [])
-var sbot_search = plugs.first(exports.sbot_search = [])
+var sbot_log = plugs.first(exports.sbot_log = [])
+
+function searchFilter(query) {
+  var search = new RegExp(query, 'i')
+  return function (msg) {
+    var c = msg && msg.value && msg.value.content
+    return c && (
+      msg.key == query ||
+      c.text && search.test(c.text) ||
+      c.name && search.test(c.name) ||
+      c.title && search.test(c.title))
+  }
+}
 
 exports.screen_view = function (path) {
   if(path[0] === '?') {
     var query = path.substr(1)
+    var matchesQuery = searchFilter(query)
 
     var content = h('div.column.scroller__content')
     var div = h('div.column.scroller',
@@ -20,13 +33,14 @@ exports.screen_view = function (path) {
     )
 
     pull(
-      sbot_search({query: query, old: false}),
+      sbot_log({old: false}),
+      pull.filter(matchesQuery),
       Scroller(div, content, message_render, true, false)
     )
 
     pull(
-      u.next(sbot_search, {query: query,
-        reverse: true, limit: 100, live: false}),
+      u.next(sbot_log, {reverse: true, limit: 500, live: false}),
+      pull.filter(matchesQuery),
       Scroller(div, content, message_render, false, false)
     )
 

--- a/modules/tabs.js
+++ b/modules/tabs.js
@@ -40,12 +40,12 @@ exports.app = function () {
     onkeydown: function (ev) {
       switch (ev.keyCode) {
         case 13: // enter
-          var path = '?' + search.value
+          var path = search.value
           if(tabs.has(path)) return tabs.select(path)
           var el = screen_view(path)
           if(el) {
             el.scroll = keyscroll(el.querySelector('.scroller__content'))
-            tabs.add('?' + search.value, el, !ev.ctrlKey)
+            tabs.add(path, el, !ev.ctrlKey)
             localStorage.openTabs = JSON.stringify(tabs.tabs)
             search.blur()
           }
@@ -58,6 +58,17 @@ exports.app = function () {
     }
   })
   tabs.insertBefore(search, tabs.querySelector('.hypertabs__content'))
+
+  function activateSearch(sigil, ev) {
+    search.focus()
+    ev.preventDefault()
+    if (search.value[0] === sigil) {
+      search.selectionStart = 1
+      search.selectionEnd = search.value.length
+    } else {
+      search.value = sigil
+    }
+  }
 
   var saved
   try { saved = JSON.parse(localStorage.openTabs) }
@@ -121,10 +132,13 @@ exports.app = function () {
 
       // activate the search field
       case 191: // /
-        ev.preventDefault()
-        search.focus()
-        search.selectionStart = 0
-        search.selectionEnd = search.value.length
+        activateSearch('?', ev)
+        return
+
+      // navigate to a channel
+      case 51: // 3
+        if (ev.shiftKey)
+          activateSearch('#', ev)
         return
     }
   })

--- a/modules/thread.js
+++ b/modules/thread.js
@@ -96,6 +96,7 @@ exports.screen_view = function (id, sbot) {
         var branches = sort.heads(thread)
         meta.branch = branches.length > 1 ? branches : branches[0]
         meta.root = thread[0].value.content.root || thread[0].key
+        meta.channel = thread[0].value.content.channel
 
         var recps = thread[0].value.content.recps
         if(recps && thread[0].value.private)

--- a/sbot-api.js
+++ b/sbot-api.js
@@ -46,6 +46,9 @@ module.exports = function () {
     sbot_links2: rec.source(function (query) {
       return sbot.links2.read(query)
     }),
+    sbot_query: rec.source(function (query) {
+      return sbot.query.read(query)
+    }),
     sbot_log: rec.source(function (opts) {
       return sbot.createLogStream(opts)
     }),

--- a/sbot-api.js
+++ b/sbot-api.js
@@ -52,23 +52,6 @@ module.exports = function () {
     sbot_user_feed: rec.source(function (opts) {
       return sbot.createUserStream(opts)
     }),
-    sbot_search: rec.source(function (opts) {
-      var search = new RegExp(opts.query, 'i')
-      var limit = opts.limit || Infinity
-      delete opts.limit
-      return pull(
-        sbot.createLogStream(opts),
-        pull.filter(function (msg) {
-          var c = msg && msg.value && msg.value.content
-          return c && (
-            msg.key == opts.query ||
-            c.text && search.test(c.text) ||
-            c.name && search.test(c.name) ||
-            c.title && search.test(c.title))
-        }),
-        pull.take(limit)
-      )
-    }),
     sbot_get: rec.async(function (key, cb) {
       sbot.get(key, cb)
     }),

--- a/sbot-api.js
+++ b/sbot-api.js
@@ -52,6 +52,23 @@ module.exports = function () {
     sbot_user_feed: rec.source(function (opts) {
       return sbot.createUserStream(opts)
     }),
+    sbot_search: rec.source(function (opts) {
+      var search = new RegExp(opts.query, 'i')
+      var limit = opts.limit || Infinity
+      delete opts.limit
+      return pull(
+        sbot.createLogStream(opts),
+        pull.filter(function (msg) {
+          var c = msg && msg.value && msg.value.content
+          return c && (
+            msg.key == opts.query ||
+            c.text && search.test(c.text) ||
+            c.name && search.test(c.name) ||
+            c.title && search.test(c.title))
+        }),
+        pull.take(limit)
+      )
+    }),
     sbot_get: rec.async(function (key, cb) {
       sbot.get(key, cb)
     }),

--- a/style.css
+++ b/style.css
@@ -133,6 +133,10 @@ input {
   width: 200px;
 }
 
+.suggest-box .selected {
+  background: yellow;
+}
+
 .suggest-box img {
   width: 50px;
 }

--- a/style.css
+++ b/style.css
@@ -156,3 +156,13 @@ input {
 .lightbox {
   overflow: auto;
 }
+
+/* searchprompt */
+
+.searchprompt {
+  position: absolute;
+}
+
+.searchprompt:not(:focus) {
+  opacity: 0;
+}


### PR DESCRIPTION
This adds search, including a message view where a path for a search query starts with a '?', and a keybinding of '/' to activate the search field. The search is basically a grep of the log, like how Patchwork and git-ssb-web do it.
Also I did a minor refactor of how keyscroll is used, and other minor changes.

Currently search causes patchwork/sbot's CPU usage to go high for a while, I think because the operation reads the whole log and muxprc doesn't pass through the backpressure. I think I might be able to work around this by using `u.next()` to combine multiple requests with `limit: N` instead of doing an unlimited request and `take(N)`. Also, if a search query returns no results, the use of `u.next()` triggers the query to be repeated after the stream ends, even after the search tab is closed.