### PR TITLE
Add channel view

### DIFF
--- a/modules/channel.js
+++ b/modules/channel.js
@@ -1,0 +1,52 @@
+var h = require('hyperscript')
+var u = require('../util')
+var pull = require('pull-stream')
+var Scroller = require('pull-scroll')
+
+var plugs = require('../plugs')
+var message_render = plugs.first(exports.message_render = [])
+var message_compose = plugs.first(exports.message_compose = [])
+var sbot_log = plugs.first(exports.sbot_log = [])
+var sbot_query = plugs.first(exports.sbot_query = [])
+
+exports.message_meta = function (msg) {
+  var chan = msg.value.content.channel
+  if (chan)
+    return h('a', {href: '##'+chan}, '#'+chan)
+}
+
+exports.screen_view = function (path) {
+  if(path[0] === '#') {
+    var channel = path.substr(1)
+
+    var content = h('div.column.scroller__content')
+    var div = h('div.column.scroller',
+      {style: {'overflow':'auto'}},
+      h('div.scroller__wrapper',
+        message_compose({type: 'post', channel: channel}),
+        content
+      )
+    )
+
+    function matchesChannel(msg) {
+      if (msg.sync) console.error('SYNC', msg)
+      var c = msg && msg.value && msg.value.content
+      return c && c.channel === channel
+    }
+
+    pull(
+      sbot_log({old: false}),
+      pull.filter(matchesChannel),
+      Scroller(div, content, message_render, true, false)
+    )
+
+    pull(
+      sbot_query({reverse: true, query: [
+        {$filter: {value: {content: {channel: channel}}}}
+      ]}),
+      Scroller(div, content, message_render, false, false)
+    )
+
+    return div
+  }
+}

--- a/modules/index.js
+++ b/modules/index.js
@@ -3,6 +3,7 @@ module.exports = [
   require('./avatar-image.js'),
   require('./avatar-profile.js'),
   require('./avatar.js'),
+  require('./channel.js'),
   require('./compose.js'),
   require('./crypto.js'),
   require('./feed.js'),

--- a/sbot-api.js
+++ b/sbot-api.js
@@ -46,6 +46,9 @@ module.exports = function () {
     sbot_links2: rec.source(function (query) {
       return sbot.links2.read(query)
     }),
+    sbot_query: rec.source(function (query) {
+      return sbot.query.read(query)
+    }),
     sbot_log: rec.source(function (opts) {
       return sbot.createLogStream(opts)
     }),


### PR DESCRIPTION
pulled out of #8

This adds a screen_view for channels (tab paths starting with '#'),
and adds a message_meta for messages to indicate their channel.

Performance of loading channel tabs is improved significantly by dominictarr/ssb-query#1