### PR TITLE
search respects word boundries and multiple terms

### DIFF
--- a/modules/search.js
+++ b/modules/search.js
@@ -27,15 +27,21 @@ function searchFilter(terms) {
     return c && (
       msg.key == terms[0] ||
       andSearch(terms.map(function (term) {
-        return new RegExp(term, 'i')
+        return new RegExp('\\b'+term+'\\b', 'i')
       }), [c.text, c.name, c.title])
     )
   }
 }
 
+function createOrRegExp(ary) {
+  return new RegExp(ary.map(function (e) {
+    return '\\b'+e+'\\b'
+  }).join('|'), 'i')
+}
+
 function highlight(el, query) {
   var searcher = new TextNodeSearcher({container: el})
-  searcher.setQuery(query)
+  searcher.query = query
   searcher.highlight()
   return el
 }
@@ -55,9 +61,7 @@ exports.screen_view = function (path) {
 
     function renderMsg(msg) {
       var el = message_render(msg)
-      query.forEach(function (term) {
-        highlight(el, term)
-      })
+      highlight(el, createOrRegExp(query))
       return el
     }
 
@@ -76,18 +80,4 @@ exports.screen_view = function (path) {
     return div
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/modules/search.js
+++ b/modules/search.js
@@ -7,22 +7,42 @@ var TextNodeSearcher = require('text-node-searcher')
 var plugs = require('../plugs')
 var message_render = plugs.first(exports.message_render = [])
 var sbot_log = plugs.first(exports.sbot_log = [])
+var whitespace = /\s+/
 
-function searchFilter(query) {
-  var search = new RegExp('\\b('+query+')\\b', 'i')
+function andSearch(terms, inputs) {
+  for(var i = 0; i < terms.length; i++) {
+    var match = false
+    for(var j = 0; j < inputs.length; j++) {
+      if(terms[i].test(inputs[j])) match = true
+    }
+    //if a term was not matched by anything, filter this one
+    if(!match) return false
+  }
+  return true
+}
+
+function searchFilter(terms) {
   return function (msg) {
     var c = msg && msg.value && msg.value.content
     return c && (
-      msg.key == query ||
-      c.text && search.test(c.text) ||
-      c.name && search.test(c.name) ||
-      c.title && search.test(c.title))
+      msg.key == terms[0] ||
+      andSearch(terms.map(function (term) {
+        return new RegExp(term, 'i')
+      }), [c.text, c.name, c.title])
+    )
   }
+}
+
+function highlight(el, query) {
+  var searcher = new TextNodeSearcher({container: el})
+  searcher.setQuery(query)
+  searcher.highlight()
+  return el
 }
 
 exports.screen_view = function (path) {
   if(path[0] === '?') {
-    var query = path.substr(1)
+    var query = path.substr(1).trim().split(whitespace)
     var matchesQuery = searchFilter(query)
 
     var content = h('div.column.scroller__content')
@@ -35,9 +55,9 @@ exports.screen_view = function (path) {
 
     function renderMsg(msg) {
       var el = message_render(msg)
-      var searcher = new TextNodeSearcher({container: el})
-      searcher.setQuery(query)
-      searcher.highlight()
+      query.forEach(function (term) {
+        highlight(el, term)
+      })
       return el
     }
 
@@ -56,3 +76,18 @@ exports.screen_view = function (path) {
     return div
   }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/modules/search.js
+++ b/modules/search.js
@@ -9,7 +9,7 @@ var message_render = plugs.first(exports.message_render = [])
 var sbot_log = plugs.first(exports.sbot_log = [])
 
 function searchFilter(query) {
-  var search = new RegExp(query, 'i')
+  var search = new RegExp('\\b('+query+')\\b', 'i')
   return function (msg) {
     var c = msg && msg.value && msg.value.content
     return c && (


### PR DESCRIPTION
@clehner more search stuff.

matches on exact word boundries and supports multiple search terms.
this makes search quite a bit more useful.

i'm not 100% sure about using exact word boundries, but it should probably be the default.
I tried to search for number5's post about address-something. I rememebered the word "address",
but i didn't remember it was "addressable" maybe the answer is globbing? `address*`?

or maybe stemming? but is there a language agnostic way to do stemming? (guessing maybe with markov chains?)

I'm quite impressed with how well brute force search is working!

Also, I'm noticing that feeds + keyboard scroll, and suggest + keyboard select is very similar. we could make these all use the same modules, and if we had a compact way to render a message, have suggest-for-messages in composer too.