### PR TITLE
Right align message metadata

### DIFF
--- a/modules/avatar-profile.js
+++ b/modules/avatar-profile.js
@@ -6,7 +6,7 @@ var avatar_action = plugs.map(exports.avatar_action = [])
 
 exports.avatar_profile = function (id) {
 
-  return h('div.row',
+  return h('div.row.profile',
     avatar_image(id),
     h('div.column', avatar_action(id))
   )

--- a/style.css
+++ b/style.css
@@ -143,8 +143,8 @@ input {
   background: #ddd;
 }
 
-.message > .title > .message_meta {
-  margin-left: 5px;
+.message_meta {
+  margin-left: auto;
 }
 .message > .title > .avatar {
   margin-left: 0;

--- a/style.css
+++ b/style.css
@@ -54,6 +54,7 @@ img {
 
 pre {
   max-width: 650px;
+  white-space: pre-wrap;
 //  overflow-x: auto;
 //  overflox-y: none;
 }
@@ -131,6 +132,8 @@ input {
   flex-basis: 0;
   max-width: 100%;
   min-width: 300px;
+  word-wrap:break-word; 
+  display:inline-block;
 }
 
 .message_meta input {
@@ -144,7 +147,7 @@ input {
   margin-left: 5px;
 }
 .message > .title > .avatar {
-  margin-left: 5px;
+  margin-left: 0;
 }
 
 .message_content {
@@ -157,22 +160,29 @@ input {
 
 
 .suggest-box > * {
-  background: white;
+  background: #f5f5f5;
+  border: 1px solid #ccc;
   margin: 3px;
 }
 
-.suggest-box{
+.suggest-box {
 //  display: flex;
 //  flex-direction: row;
   width: 200px;
+  margin-left: -7em;
+}
+
+.suggest-box ul {
+  list-style-type: none;
+  padding-left: -20px;
 }
 
 .suggest-box .selected {
-  background: yellow;
+  background: #ccc;
 }
 
 .suggest-box img {
-  width: 50px;
+  width: 40px;
 }
 .suggest-box,.selected img {
   width: 200px;
@@ -191,18 +201,34 @@ input {
   border: 1px solid #ccc;
 }
 
+.profile {
+  background: #fff;
+  border: 1px solid #ccc;
+}
+
+.profile img {
+  width: 150px;
+  height: 150px;
+  margin-right: 1em;
+  margin-bottom: 1em;
+  border: 1px solid #ccc;
+}
+
 /* lightbox - used in message-confirm */
 
 .lightbox {
   overflow: auto;
+  width: 80%;
+  border: 1px solid #ccc; // this is being overwritten in hyperlightbox module
 }
 
 /* searchprompt */
 
 .searchprompt {
   position: absolute;
+  right: 10px;
   top: 10px;
-  right: 15px;
+  width: 200px;
 }
 
 .searchprompt:not(:focus) {
@@ -219,6 +245,6 @@ a:hover {
 
 /* TextNodeSearcher highlights */
 
-highlight {
+.highlight {
   background: yellow;
 }


### PR DESCRIPTION
I think this looks better.
![screenshot_right-align-meta](https://cloud.githubusercontent.com/assets/259374/16536683/f5f101b0-4048-11e6-989c-5cd7da429053.png)

i think the next thing is the ID input is ugly. That could be a "copy id" option like patchwork has,
or also there could be a header that appears on the message view (i.e. the thread page) which would have a selectable input box.

