### PR TITLE
Keep timestamps up-to-date

### DIFF
--- a/modules/timestamp.js
+++ b/modules/timestamp.js
@@ -1,6 +1,19 @@
 var h = require('hyperscript')
 var moment = require('moment')
 
+function updateTimestampEl(el) {
+  el.firstChild.nodeValue = moment(el.timestamp).fromNow()
+  return el
+}
+
+setInterval(function () {
+  var els = [].slice.call(document.querySelectorAll('.timestamp'))
+  els.forEach(updateTimestampEl)
+}, 60e3)
+
 exports.message_meta = function (msg) {
-  return h('a.enter', {href: '#'+msg.key}, moment(msg.value.timestamp).fromNow())
+  return updateTimestampEl(h('a.enter.timestamp', {
+    href: '#'+msg.key,
+    timestamp: msg.value.timestamp
+  }, ''))
 }

--- a/modules/timestamp.js
+++ b/modules/timestamp.js
@@ -2,7 +2,7 @@ var h = require('hyperscript')
 var moment = require('moment')
 
 function updateTimestampEl(el) {
-  el.firstChild.nodeValue = moment(el.timestamp).fromNow()
+  el.firstChild.nodeValue = el.timestamp.fromNow()
   return el
 }
 
@@ -12,8 +12,10 @@ setInterval(function () {
 }, 60e3)
 
 exports.message_meta = function (msg) {
+  var m = moment(msg.value.timestamp)
   return updateTimestampEl(h('a.enter.timestamp', {
     href: '#'+msg.key,
-    timestamp: msg.value.timestamp
+    timestamp: m,
+    title: m.format('LLLL')
   }, ''))
 }


### PR DESCRIPTION
Once a minute re-render all timestamps on the page.
Show full datetime string in `title` tooltip.
This makes it easier to tell when things were posted.