### PR TITLE
yups to digs, digs to bottom right corner

### DIFF
--- a/modules/like.js
+++ b/modules/like.js
@@ -27,7 +27,7 @@ exports.message_meta = function (msg, sbot) {
     pull.collect(function (err, votes) {
       if(votes.length === 1)
         digs.textContent = ' 1 Dig'
-      if(votes.length)
+      if(votes.length > 1)
         digs.textContent = ' ' + votes.length + ' Digs'
     })
   )

--- a/modules/like.js
+++ b/modules/like.js
@@ -13,45 +13,45 @@ exports.message_content = function (msg, sbot) {
   if(msg.value.content.type !== 'vote') return
   var link = msg.value.content.vote.link
   return h('div',
-      msg.value.content.vote.value > 0 ? 'yup' : 'nah',
+      msg.value.content.vote.value > 0 ? 'Dug' : 'Undug',
       ' ', message_link(link)
     )
 }
 
 exports.message_meta = function (msg, sbot) {
 
-  var yupps = h('a')
+  var digs = h('a')
 
   pull(
     sbot_links({dest: msg.key, rel: 'vote'}),
     pull.collect(function (err, votes) {
       if(votes.length === 1)
-        yupps.textContent = ' 1 yup'
+        digs.textContent = ' 1 Dig'
       if(votes.length)
-        yupps.textContent = ' ' + votes.length + ' yupps'
+        digs.textContent = ' ' + votes.length + ' Digs'
     })
   )
 
-  return yupps
+  return digs
 }
 
 exports.message_action = function (msg, sbot) {
   if(msg.value.content.type !== 'vote')
     return h('a', {href: '#', onclick: function () {
-      var yup = {
+      var dig = {
         type: 'vote',
-        vote: { link: msg.key, value: 1, expression: 'yup' }
+        vote: { link: msg.key, value: 1, expression: 'Dig' }
       }
       if(msg.value.content.recps) {
-        yup.recps = msg.value.content.recps.map(function (e) {
+        dig.recps = msg.value.content.recps.map(function (e) {
           return e && typeof e !== 'string' ? e.link : e
         })
-        yup.private = true
+        dig.private = true
       }
       //TODO: actually publish...
 
-      message_confirm(yup)
-    }}, 'yup')
+      message_confirm(dig)
+    }}, 'Dig')
 
 }
 

--- a/modules/message.js
+++ b/modules/message.js
@@ -38,7 +38,10 @@ exports.message_render = function (msg, sbot) {
     ),
     h('div.message_content', el),
     h('div.message_actions.row',
-      h('div.actions', message_action(msg))
+      h('div.actions', message_action(msg),
+        h('span', ' '), 
+        h('a', {href: '#' + msg.key}, 'Reply')
+      )
     ),
     backlinks,
     {onkeydown: function (ev) {

--- a/modules/message.js
+++ b/modules/message.js
@@ -38,8 +38,7 @@ exports.message_render = function (msg, sbot) {
     ),
     h('div.message_content', el),
     h('div.message_actions.row',
-      h('div.actions', message_action(msg),
-        h('span', ' '), 
+      h('div.actions', message_action(msg), ' | ',
         h('a', {href: '#' + msg.key}, 'Reply')
       )
     ),

--- a/modules/message.js
+++ b/modules/message.js
@@ -38,7 +38,7 @@ exports.message_render = function (msg, sbot) {
     ),
     h('div.message_content', el),
     h('div.message_actions.row',
-      h('div.actions', message_action(msg), ' | ',
+      h('div.actions', message_action(msg), ' ',
         h('a', {href: '#' + msg.key}, 'Reply')
       )
     ),

--- a/style.css
+++ b/style.css
@@ -248,4 +248,3 @@ highlight {
   background: yellow;
 }
 
-.vote { float: right; }

--- a/style.css
+++ b/style.css
@@ -109,11 +109,11 @@ pre {
 input {
   margin-left: 3px;
   margin-right: 3px;
-  border: 1px solid #ccc;
+  border: 1px solid #eee;
 }
 
 textarea {
-  border: 1px solid #ccc;
+  border: 1px solid #eee;
 }
 
 /* compose */
@@ -125,9 +125,9 @@ textarea {
 /* messages */
 
 .message {
-  border: 1px solid #ccc;
+  border: 1px solid #eee;
   padding: 5px;
-  margin-top: 1em;
+  margin-top: .5em;
   background: white;
   display: block;
   flex-basis: 0;
@@ -160,7 +160,7 @@ textarea {
 
 .message_content {
   margin-top: 5px;
-  border-top: 1px solid #ccc;
+  border-top: 1px solid #eee;
   padding-top: 3px;
 }
 
@@ -207,7 +207,7 @@ textarea {
 
 .profile {
   background: #fff;
-  border: 1px solid #ccc;
+  border: 1px solid #eee;
 }
 
 .profile img {

--- a/style.css
+++ b/style.css
@@ -222,9 +222,19 @@ textarea {
 
 .lightbox {
   overflow: auto;
-  width: 80%;
-  border: 1px solid #ccc; // this is being overwritten in hyperlightbox module
+  background: #fff;
+  width: 600px;
+  border: 1px solid #eee;
+  top: 2em;
+  bottom: 2em;
+  left: 2em;
+  right: 2em;
+  padding: 1em;
 }
+
+.message-confirm {
+  background: #fff;
+} 
 
 /* searchprompt */
 

--- a/style.css
+++ b/style.css
@@ -150,6 +150,10 @@ textarea {
 .message_meta > * {
   margin-left: 5px;
 }
+.message_actions {
+  float: right;
+}
+
 .message > .title > .avatar {
   margin-left: 0;
 }
@@ -244,3 +248,4 @@ highlight {
   background: yellow;
 }
 
+.vote { float: right; }


### PR DESCRIPTION
I changed yups to digs for consistency across the three apps, Patchwork/git-ssb-web/Patchbay. Feel free to reject if yup is preferred. 

In the future perhaps the deployer can set this to 'Star' or 'Yarr' in a config file?

WIP commit. Next I'm going to try to get voting into the bottom right corner of the screen. Next next I'm going to try to get a reply button down there too.

Ok this is mostly accomplished. The one goal I have is to remove the ' | ' when there is no dig button.