### PR TITLE
stabbing in the dark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules
 npm-debug.log
 .npmignore
 build
-

--- a/modules/audio-mp3.js
+++ b/modules/audio-mp3.js
@@ -1,0 +1,49 @@
+var markdown = require('ssb-markdown');
+var h = require('hyperscript');
+var u = require('../util');
+var ref = require('ssb-ref');
+
+//render a message
+
+var plugs = require('../plugs');
+var message_link = plugs.first(exports.message_link = []);
+var message_confirm = plugs.first(exports.message_confirm = []);
+var sbot_links = plugs.first(exports.sbot_links = []);
+
+exports.message_content = function(msg, sbot) {
+    if (msg.value.content.type !== 'audio-mp3')
+        return;
+
+    var v = msg.value.content;
+    return h('div',
+        h('h2', "(" + v.Track + ") " + v.Title),
+        // h('img', { "src" : "http://localhost:7777/" + encodeURIComponent(v.cover) }),
+        h('audio', {
+                 "controls" : true,
+                 "src" : "http://localhost:7777/" + encodeURIComponent(v.link)
+             }))
+    // h('dl',
+    //          Object.keys(v).map(function(k) {
+    //              return [
+    //                  h("dt", k),
+    //                  h("dd", v[k]),
+    //              ]
+    //          })))
+
+    // "Album": "the fall of",
+    //     "Crc32": "038becab",
+    //     "Creator": "bleupulp",
+    //     "Format": "VBR MP3",
+    //     "Height": "0",
+    //     "Length": "375.23",
+    //     "Md5": "2c517c8e813da5f940c8c7e77d4b7f3f",
+    //     "Mtime": "1399498698",
+    //     "Name": "2_bleupulp_-_clouds.mp3",
+    //     "Sha1": "9f6a96a3d5571ed1ec2a7da38ffebdcd5f181482",
+    //     "Size": "15009000",
+
+    //     "Title": "clouds",
+    //     "Track": "2",
+    //     "Width": "0",
+
+}

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   "_screen_view.js":  require('./_screen_view.js'),
   "about.js":  require('./about.js'),
+  "audio-mp3.js":  require('./audio-mp3.js'),
   "avatar-image.js":  require('./avatar-image.js'),
   "avatar-profile.js":  require('./avatar-profile.js'),
   "avatar.js":  require('./avatar.js'),
@@ -18,6 +19,9 @@ module.exports = {
   "message-link.js":  require('./message-link.js'),
   "message-name.js":  require('./message-name.js'),
   "message.js":  require('./message.js'),
+  "meta-image.js":  require('./meta-image.js'),
+  "music-release-cc.js":  require('./music-release-cc.js'),
+  "music-release.js":  require('./music-release.js'),
   "names.js":  require('./names.js'),
   "notifications.js":  require('./notifications.js'),
   "post.js":  require('./post.js'),

--- a/modules/meta-image.js
+++ b/modules/meta-image.js
@@ -1,0 +1,46 @@
+var markdown = require('ssb-markdown');
+var h = require('hyperscript');
+var u = require('../util');
+var ref = require('ssb-ref');
+
+//render a message
+
+var plugs = require('../plugs');
+var message_link = plugs.first(exports.message_link = []);
+var message_confirm = plugs.first(exports.message_confirm = []);
+var sbot_links = plugs.first(exports.sbot_links = []);
+
+exports.message_content = function(msg, sbot) {
+    if (msg.value.content.type !== 'meta-image')
+        return;
+
+    var v = msg.value.content;
+    return h('div',
+        // h('h2', "(" + v.Track + ") " + v.Title),
+        h('img', { "src" : "http://localhost:7777/" + encodeURIComponent(v.link) }))
+
+    // h('dl',
+    //          Object.keys(v).map(function(k) {
+    //              return [
+    //                  h("dt", k),
+    //                  h("dd", v[k]),
+    //              ]
+    //          })))
+
+    // "Album": "the fall of",
+    //     "Crc32": "038becab",
+    //     "Creator": "bleupulp",
+    //     "Format": "VBR MP3",
+    //     "Height": "0",
+    //     "Length": "375.23",
+    //     "Md5": "2c517c8e813da5f940c8c7e77d4b7f3f",
+    //     "Mtime": "1399498698",
+    //     "Name": "2_bleupulp_-_clouds.mp3",
+    //     "Sha1": "9f6a96a3d5571ed1ec2a7da38ffebdcd5f181482",
+    //     "Size": "15009000",
+
+    //     "Title": "clouds",
+    //     "Track": "2",
+    //     "Width": "0",
+
+}

--- a/modules/music-release-cc.js
+++ b/modules/music-release-cc.js
@@ -1,0 +1,78 @@
+var markdown = require('ssb-markdown');
+var h = require('hyperscript');
+var u = require('../util');
+var ref = require('ssb-ref');
+
+//render a message
+
+var plugs = require('../plugs');
+var message_link = plugs.first(exports.message_link = []);
+var message_confirm = plugs.first(exports.message_confirm = []);
+var sbot_links = plugs.first(exports.sbot_links = []);
+
+exports.message_content = function(msg, sbot) {
+    if (msg.value.content.type !== 'music-release-cc')
+        return;
+
+    var tracks = msg.value.content.tracks;
+    return h('div',
+        h('img', { "src" : "http://localhost:7777/" + encodeURIComponent(msg.value.content.cover) }),
+        h('h1', msg.value.content.title),
+        h('ol',
+                 Object.keys(tracks).map(function(k) {
+                     var t = tracks[k];
+                     return h('li', t.fname,
+                         h("br"),
+                         h('audio', {
+                                  "controls" : true,
+                                  "src" : "http://localhost:7777/" + encodeURIComponent(t.link)
+                              }))
+                 })),
+        h('p',
+                 "More info:", h('a', { href : msg.value.content.archivedotorg }, "archive.org"),
+                 h("br"),
+                 "License:", h('a', { href : msg.value.content.license }, "Link")))
+}
+
+// copied from like.js
+
+// inspiration for waveform range selection
+
+// idea: handout invite codes for upload of tracks to be cached by the pub
+
+// exports.message_meta = function (msg, sbot) {
+
+//   var yupps = h('a')
+
+//   pull(
+//     sbot_links({dest: msg.key, rel: 'vote'}),
+//     pull.collect(function (err, votes) {
+//       if(votes.length === 1)
+//         yupps.textContent = ' 1 yup'
+//       if(votes.length)
+//         yupps.textContent = ' ' + votes.length + ' yupps'
+//     })
+//   )
+
+//   return yupps
+// }
+
+// exports.message_action = function (msg, sbot) {
+//   if(msg.value.content.type !== 'vote')
+//     return h('a', {href: '#', onclick: function () {
+//       var yup = {
+//         type: 'vote',
+//         vote: { link: msg.key, value: 1, expression: 'yup' }
+//       }
+//       if(msg.value.content.recps) {
+//         yup.recps = msg.value.content.recps.map(function (e) {
+//           return e && typeof e !== 'string' ? e.link : e
+//         })
+//         yup.private = true
+//       }
+//       //TODO: actually publish...
+
+//       message_confirm(yup)
+//     }}, 'yup')
+
+// }

--- a/modules/music-release.js
+++ b/modules/music-release.js
@@ -1,0 +1,41 @@
+var markdown = require('ssb-markdown');
+var h = require('hyperscript');
+var u = require('../util');
+var ref = require('ssb-ref');
+
+//render a message
+
+var plugs = require('../plugs');
+var message_link = plugs.first(exports.message_link = []);
+var message_confirm = plugs.first(exports.message_confirm = []);
+var sbot_links = plugs.first(exports.sbot_links = []);
+
+exports.message_content = function(msg, sbot) {
+    if (msg.value.content.type !== 'music-release')
+        return;
+
+    var v = msg.value.content;
+    return h('div',
+        // h('img', { "src" : "http://localhost:7777/" + encodeURIComponent(v.cover) }),
+        h('h1', v.Title),
+        h("p", v.Description),
+        h("dl",
+
+                 h("dt", "Creator"),
+                 h("dd", v.Creator),
+
+                 h("dt", "Identifier"),
+                 h("dd", v.Identifier),
+
+                 h("dt", "Published"),
+                 h("dd", v.Publicdate),
+
+                 h("dt", "Runtime"),
+                 h("dd", v.Runtime),
+
+                 h("dt", "Source"),
+                 h("dd", v.Source),
+
+                 h("dt", "License"),
+                 h("dd", h('a', { href : v.Licenseurl }, "Link"))))
+}

--- a/music-release.json
+++ b/music-release.json
@@ -1,0 +1,8 @@
+{
+    "type": "music-release",
+    "title": "(miniatura070) bleupulp - the fall of",
+    "archivedotorg": "https://archive.org/details/Miniatura070Bleupulp-theFallOf",
+    "license":"https://creativecommons.org/licenses/by-nc-nd/3.0/",
+    "cover": "&2JGx5HkFts0PS84K3xwKGZZgqQ5zAf2LSuLAahBhm6I=.sha256",
+    "ipfs": "/ipfs/QmSuUXxGsF7yQNPDQEjUsAmWZZoNNmdMmZK59MsQroX3ch"
+}

--- a/music-tracks.json
+++ b/music-tracks.json
@@ -1,0 +1,36 @@
+{
+    "tracks": [
+        {
+            "root": "%FD6hYornRa2ZuaPtoTHMf5t8Vp9PHM6IYmyJfBUjIXs=.sha256",
+            "branch": "%FD6hYornRa2ZuaPtoTHMf5t8Vp9PHM6IYmyJfBUjIXs=.sha256",
+            "size": 2157326,
+            "text": "1_bleupulp_-_clouds_intro.ogg",
+            "type": "audio/ogg",
+            "link": "&A70FAlwssY77iSfqcg/NVj9LCcsoITASHwM/r+wbNU0=.sha256"
+        },
+        {
+            "root": "%FD6hYornRa2ZuaPtoTHMf5t8Vp9PHM6IYmyJfBUjIXs=.sha256",
+            "branch": "%FD6hYornRa2ZuaPtoTHMf5t8Vp9PHM6IYmyJfBUjIXs=.sha256",
+            "size": 4646474,
+            "text": "2_bleupulp_-_clouds.ogg",
+            "type": "audio/ogg",
+            "link": "&xjkBIJa6kHFkaeCUl9P1koJEjJa7L5AZKHs6uYEmlOI=.sha256"
+        },
+        {
+            "root": "%FD6hYornRa2ZuaPtoTHMf5t8Vp9PHM6IYmyJfBUjIXs=.sha256",
+            "branch": "%FD6hYornRa2ZuaPtoTHMf5t8Vp9PHM6IYmyJfBUjIXs=.sha256",
+            "size": 5163650,
+            "text": "3_bleupulp_-_after_the.ogg",
+            "type": "audio/ogg",
+            "link": "&4F/x0KQejrjU1ymPHq/WHtcAxh2tWVprsxAvGOPwh0Q=.sha256"
+        },
+        {
+            "root": "%FD6hYornRa2ZuaPtoTHMf5t8Vp9PHM6IYmyJfBUjIXs=.sha256",
+            "branch": "%FD6hYornRa2ZuaPtoTHMf5t8Vp9PHM6IYmyJfBUjIXs=.sha256",
+            "size": 5105666,
+            "text": "4_bleupulp_-_hi0low.ogg",
+            "type": "audio/ogg",
+            "link": "&gCRNeGQk/V42cbn6NRmWZSmdDDWOQ5DHymVRqXCk8q8=.sha256"
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "mime-types": "^2.1.11",
     "moment": "^2.13.0",
     "open-external": "^0.1.1",
+    "peaks.js": "^0.4.7",
     "pull-cat": "^1.1.9",
     "pull-next": "0.0.0",
     "pull-paramap": "^1.1.6",


### PR DESCRIPTION
This adds two approaches for adding music to patchbay:

* `music-release-cc.js` displays `type: music-release-cc` posts (like `%e/JG0Stf90f4FBpBSPC+OAwl5EAIL5Xz3LFz0mhgpl8=.sha256`)
* `music-relase.js` and friends which depend on (`root`,`branch`)  linked `meta-image`, `audio-mp3` type posts to aggregate a release. I linked some examples of this in `%KgIliFBy5MeXafVENTNkRVHdFTy+d+T2zGSy9EuSYBg=.sha256`)

Visually I like the first approach more but dislike the _fat_ objects it uses. The 2nd approach gives you the option to dig/pin/star/whatever individual tracks/meta and recompile them in playlists for instance.

