### PR TITLE
WIP: use hash for 'routing'

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,37 +8,10 @@ var SbotApi = require('./sbot-api')
 
 var modules = require('./modules')
 
-var renderers = []
-var app = []
-//var App = require('./plugs').first(app)
-
 var u = require('./util')
 
-//modules.unshift(SbotApi())
-//modules.unshift({app: app})
-
-//var indexes = fs.readdirSync(path.join(__dirname, 'modules'))
-//var i = indexes.indexOf('index.js')
-//indexes.splice(i, 1)
-
-//var sv = [], screen_view = require('./plugs').first(sv)
-//modules['main.js' ] = {
-//  screen_view: sv,
-//  app: function () {
-//    return h('div.row',
-//      screen_view('/public'),
-//      screen_view('/private')
-//    )
-//  }
-//}
-
-modules['app.js'] = {app: []}
-
 modules['sbot-api.js'] = SbotApi()
-
-modules['tabs.js']
-
-combine(modules) //, ['app', 'sbot'].concat(indexes) )
+combine(modules)
 
 if(process.title === 'node') {
   console.log(require('depject/graph')(modules))
@@ -49,6 +22,13 @@ document.head.appendChild(
   h('style', fs.readFileSync('./style.css', 'utf8')
 ))
 
-console.log(modules['app.js'])
-document.body.appendChild(h('div.screen.column', modules['app.js'].app[0]()))
+document.body.appendChild(modules['app.js'].app())
+
+
+
+
+
+
+
+
 

--- a/modules/app.js
+++ b/modules/app.js
@@ -1,0 +1,30 @@
+var plugs = require('../plugs')
+var h = require('hyperscript')
+
+var screen_view = plugs.first(exports.screen_view = [])
+
+exports.app = function () {
+  function hash() {
+    return window.location.hash.substring(1)
+  }
+
+  var view = screen_view(hash() || 'tabs')
+
+  var screen = h('div.screen.column', view)
+
+  window.onhashchange = function (ev) {
+    var _view = view
+    screen.replaceChild(view = screen_view(hash()), _view)
+  }
+
+  return screen
+
+}
+
+
+
+
+
+
+
+

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   "_screen_view.js":  require('./_screen_view.js'),
   "about.js":  require('./about.js'),
+  "app.js":  require('./app.js'),
   "avatar-image.js":  require('./avatar-image.js'),
   "avatar-profile.js":  require('./avatar-profile.js'),
   "avatar.js":  require('./avatar.js'),

--- a/modules/tabs.js
+++ b/modules/tabs.js
@@ -12,16 +12,19 @@ function ancestor (el) {
 }
 
 var plugs = require('../plugs')
-var screen_view = plugs.first(exports.screen_view = [])
+var screen_view = plugs.first(exports._screen_view = [])
 var search_box = plugs.first(exports.search_box = [])
 
 exports.message_render = []
 
-exports.app = function () {
+exports.screen_view = function (path) {
+  if(path !== 'tabs')
+    return
+
   var search
   var tabs = Tabs(function (name) {
     search.value = name
-    sessionStorage.selectedTab = tabs.selected
+//    sessionStorage.selectedTab = tabs.selected
   })
 //  tabs.classList.add('screen')
 
@@ -34,7 +37,7 @@ exports.app = function () {
     if(el) {
       el.scroll = keyscroll(el.querySelector('.scroller__content'))
       tabs.add(path, el, change)
-      localStorage.openTabs = JSON.stringify(tabs.tabs)
+//      localStorage.openTabs = JSON.stringify(tabs.tabs)
       return change
     }
   })
@@ -42,8 +45,8 @@ exports.app = function () {
   tabs.insertBefore(search, tabs.querySelector('.hypertabs__content'))
 
   var saved = []
-  try { saved = JSON.parse(localStorage.openTabs) }
-  catch (_) { }
+//  try { saved = JSON.parse(localStorage.openTabs) }
+//  catch (_) { }
 
   if(!saved || saved.length < 3)
     saved = ['/public', '/private', '/notifications']
@@ -55,7 +58,8 @@ exports.app = function () {
     if(el) tabs.add(path, el, false)
   })
 
-  tabs.select(sessionStorage.selectedTab || saved[0] || '/public')
+//  tabs.select(sessionStorage.selectedTab || saved[0] || '/public')
+  tabs.select('/public')
 
   tabs.onclick = function (ev) {
     var link = ancestor(ev.target)
@@ -75,7 +79,7 @@ exports.app = function () {
     if(el) {
       el.scroll = keyscroll(el.querySelector('.scroller__content'))
       tabs.add(path, el, !ev.ctrlKey)
-      localStorage.openTabs = JSON.stringify(tabs.tabs)
+//      localStorage.openTabs = JSON.stringify(tabs.tabs)
     }
 
     return false
@@ -104,7 +108,7 @@ exports.app = function () {
           var sel = tabs.selected
           tabs.selectRelative(-1)
           tabs.remove(sel)
-          localStorage.openTabs = JSON.stringify(tabs.tabs)
+//          localStorage.openTabs = JSON.stringify(tabs.tabs)
         }
         return
 
@@ -151,4 +155,3 @@ exports.app = function () {
 
   return tabs
 }
-


### PR DESCRIPTION
This PR reorganizes how the current state is managed.
it makes tabs.js just another screen_view, and means that you can you could say,
link some one directly to an invite code, instead of just sending them a url,
and then asking them to paste an invite code.

it also means you can open a tabs view as a tab recursively! although the keyboard shortcuts don't work quite right (still control the top level tabs) and I've had to disable saving the state in localStorage, that will just have to get a little bit smarter.